### PR TITLE
[fix]: improve progress initialization

### DIFF
--- a/pkg/formats/epub.go
+++ b/pkg/formats/epub.go
@@ -44,8 +44,6 @@ func NewEPUBProcessor(t translator.Translator, predefinedTranslations *config.Pr
 
 // TranslateFile 翻译EPUB文件
 func (p *EPUBProcessor) TranslateFile(inputPath, outputPath string) error {
-	p.Translator.InitTranslator()
-	defer p.Translator.Finish()
 
 	var totalChars int
 
@@ -73,6 +71,10 @@ func (p *EPUBProcessor) TranslateFile(inputPath, outputPath string) error {
 
 	p.Translator.GetProgressTracker().SetRealTotalChars(totalChars)
 	p.Translator.GetProgressTracker().SetTotalChars(totalChars)
+
+	// 初始化翻译器并开始进度跟踪
+	p.Translator.InitTranslator()
+	defer p.Translator.Finish()
 
 	// 创建临时目录
 	tempDir, err := os.MkdirTemp("", "epub_work")

--- a/pkg/formats/markdown.go
+++ b/pkg/formats/markdown.go
@@ -166,6 +166,7 @@ func (p *MarkdownProcessor) TranslateFile(inputPath, outputPath string) error {
 		FormatFile(protectedTextFile)
 
 	} else {
+		// 从已生成的受保护文本继续翻译
 		protectedTextBytes, err := os.ReadFile(protectedTextFile)
 		if err != nil {
 			p.logger.Error("无法读取保护后的文本", zap.Error(err), zap.String("文件路径", protectedTextFile))
@@ -185,6 +186,13 @@ func (p *MarkdownProcessor) TranslateFile(inputPath, outputPath string) error {
 			return fmt.Errorf("无法反序列化替换信息 %s: %v", replacementsPath, err)
 		}
 		p.currentReplacements = replacements.Replacements
+
+		// 重新计算进度信息
+		originalBytes, err := os.ReadFile(inputPath)
+		if err == nil {
+			p.Translator.GetProgressTracker().SetRealTotalChars(len(originalBytes))
+		}
+		p.Translator.GetProgressTracker().SetTotalChars(len(protectedText))
 	}
 
 	p.Translator.InitTranslator()

--- a/pkg/formats/text.go
+++ b/pkg/formats/text.go
@@ -101,6 +101,9 @@ func (p *TextProcessor) TranslateFile(inputPath, outputPath string) error {
 	}
 	p.Translator.GetProgressTracker().SetTotalChars(len(protectedText))
 
+	// 初始化翻译器并启动进度跟踪
+	p.Translator.InitTranslator()
+
 	// 分割文本为块
 	chunks := p.splitTextToChunks(protectedText, minSplitSize, maxSplitSize)
 	log.Info("文本分割完成", zap.Int("块数", len(chunks)))

--- a/pkg/translator/llm_clients.go
+++ b/pkg/translator/llm_clients.go
@@ -552,7 +552,7 @@ func (c *OpenAIClient) manualStreamRequest(ctx context.Context, req openai.ChatC
 		if err := json.Unmarshal(respBody, &jsonResponse); err == nil {
 			content := c.extractContentFromJSON(jsonResponse)
 			if content != "" {
-				c.log.Info("从错误响应中提取到有效内容",
+				c.log.Debug("从错误响应中提取到有效内容",
 					zap.String("内容", content),
 				)
 				return content, nil


### PR DESCRIPTION
## Summary
- ensure SetTotalChars updates existing trackers
- start progress only when a progress bar is provided
- recalc progress data when resuming markdown translation
- initialize translator after total chars known

## Testing
- `make test`
- `make lint` *(fails: unsupported configuration)*