### PR TITLE
[feat]: expand debug info contents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.10.3
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/litao91/goldmark-mathjax v0.0.0-20210217064022-a43cf739a50f
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/pterm/pterm v0.12.80
 	github.com/sashabaranov/go-openai v1.20.2
 	github.com/spf13/cobra v1.9.1
@@ -34,7 +35,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	TargetCurrency          string                   `mapstructure:"target_currency"`           // 目标货币单位 (例如 USD, RMB), 空字符串表示不转换
 	UsdRmbRate              float64                  `mapstructure:"usd_rmb_rate"`              // USD 到 RMB 的汇率, 用于成本估算时的货币转换
 	KeepIntermediateFiles   bool                     `mapstructure:"keep_intermediate_files"`   // 是否保留中间文件（如EPUB解压的临时文件夹）
+	SaveDebugInfo           bool                     `mapstructure:"save_debug_info"`           // 是否保存调试信息到 JSON 文件
 }
 
 // LoadConfig 从文件加载配置
@@ -184,6 +185,7 @@ func NewDefaultConfig() *Config {
 		TargetCurrency:          "",    // 默认不指定目标货币，按原始单位显示
 		UsdRmbRate:              7.4,   // 默认 USD 到 RMB 汇率
 		KeepIntermediateFiles:   false, // 默认不保留中间文件
+		SaveDebugInfo:           false,
 	}
 }
 
@@ -356,6 +358,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("target_currency", "")
 	v.SetDefault("usd_rmb_rate", 7.4)
 	v.SetDefault("keep_intermediate_files", false)
+	v.SetDefault("save_debug_info", false)
 }
 
 // structToMap 将结构体转换为map
@@ -390,5 +393,6 @@ func structToMap(config *Config) map[string]interface{} {
 		"target_currency":           config.TargetCurrency,
 		"usd_rmb_rate":              config.UsdRmbRate,
 		"keep_intermediate_files":   config.KeepIntermediateFiles,
+		"save_debug_info":           config.SaveDebugInfo,
 	}
 }

--- a/pkg/formats/epub.go
+++ b/pkg/formats/epub.go
@@ -206,6 +206,10 @@ func (p *EPUBProcessor) TranslateFile(inputPath, outputPath string) error {
 
 	p.logger.Info("EPUB文件重新打包完成", zap.String("输出文件", outputPath))
 
+	if impl, ok := p.Translator.(interface{ SaveDebugInfo(string) error }); ok {
+		_ = impl.SaveDebugInfo(outputPath)
+	}
+
 	return nil
 }
 

--- a/pkg/formats/html.go
+++ b/pkg/formats/html.go
@@ -80,6 +80,10 @@ func (p *HTMLProcessor) TranslateFile(inputPath, outputPath string) error {
 		p.logger.Warn("格式化HTML文件失败", zap.Error(err))
 	}
 
+	if impl, ok := p.Translator.(interface{ SaveDebugInfo(string) error }); ok {
+		_ = impl.SaveDebugInfo(outputPath)
+	}
+
 	p.logger.Debug("HTML文件翻译完成",
 		zap.String("输出文件", outputPath),
 		zap.Int("原始长度", len(content)),

--- a/pkg/formats/markdown.go
+++ b/pkg/formats/markdown.go
@@ -276,6 +276,9 @@ func (p *MarkdownProcessor) TranslateFile(inputPath, outputPath string) error {
 	p.Translator.GetProgressTracker().UpdateRealTranslatedChars(len(finalResult))
 
 	p.Translator.Finish()
+	if impl, ok := p.Translator.(interface{ SaveDebugInfo(string) error }); ok {
+		_ = impl.SaveDebugInfo(outputPath)
+	}
 
 	// 翻译受保护文本文件
 	translatedProtectedTextFile := strings.ReplaceAll(protectedTextFile, ".md", ".translated.md")

--- a/pkg/formats/text.go
+++ b/pkg/formats/text.go
@@ -203,6 +203,9 @@ func (p *TextProcessor) TranslateFile(inputPath, outputPath string) error {
 			p.Translator.GetProgressTracker().UpdateRealTranslatedChars(len(translatedText))
 
 			p.Translator.Finish()
+			if impl, ok := p.Translator.(interface{ SaveDebugInfo(string) error }); ok {
+				_ = impl.SaveDebugInfo(outputPath)
+			}
 
 			p.logger.Info("翻译完成",
 				zap.String("输出文件", outputPath),


### PR DESCRIPTION
## Summary
- extend debug info JSON with selected config details and step models
- mask API keys while writing model info

## Testing
- `make test`
- `make lint` *(fails: gofmt is a formatter)*